### PR TITLE
UPDATE: use latest version of filp/whoops

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
+  - 5.6
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	"require": {
 		"composer/installers": "~1.0",
 		"monolog/monolog": "^1.7",
-		"filp/whoops": "1.*"
+		"filp/whoops": "^2.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~3.7",


### PR DESCRIPTION
Have tested this on a local project and there doesn't appear to be any breaking changes from using `1.x` -> `2.x`

![screen shot 2016-01-20 at 10 49 46 am](https://cloud.githubusercontent.com/assets/1953220/12433017/8d72a47e-bf63-11e5-9373-0c897ca6296a.png)
