### PR TITLE
Changed \Exception for \Throwable to make it work on PHP7.1

### DIFF
--- a/src/Camspiers/LoggerBridge/BacktraceReporter/BacktraceReporter.php
+++ b/src/Camspiers/LoggerBridge/BacktraceReporter/BacktraceReporter.php
@@ -13,5 +13,5 @@ interface BacktraceReporter
      * @param  \Exception $exception
      * @return array
      */
-    public function getBacktrace(\Exception $exception = null);
+    public function getBacktrace(\Throwable $exception = null);
 }

--- a/src/Camspiers/LoggerBridge/BacktraceReporter/BasicBacktraceReporter.php
+++ b/src/Camspiers/LoggerBridge/BacktraceReporter/BasicBacktraceReporter.php
@@ -33,10 +33,10 @@ class BasicBacktraceReporter implements BacktraceReporter
 
     /**
      * Returns a basic backtrace
-     * @param  \Exception $exception
+     * @param  \Throwable $exception
      * @return array
      */
-    public function getBacktrace(\Exception $exception = null)
+    public function getBacktrace(\Throwable $exception = null)
     {
         $skipLimit = false;
 

--- a/src/Camspiers/LoggerBridge/BacktraceReporter/FilteredBacktraceReporter.php
+++ b/src/Camspiers/LoggerBridge/BacktraceReporter/FilteredBacktraceReporter.php
@@ -29,10 +29,10 @@ class FilteredBacktraceReporter extends BasicBacktraceReporter
 
     /**
      * Returns a filtered backtrace using regular expressions
-     * @param  \Exception $exception
+     * @param  \Throwable $exception
      * @return array|void
      */
-    public function getBacktrace(\Exception $exception = null)
+    public function getBacktrace(\Throwable $exception = null)
     {
         $backtrace = parent::getBacktrace($exception);
 

--- a/src/Camspiers/LoggerBridge/ErrorReporter/DebugErrorReporter.php
+++ b/src/Camspiers/LoggerBridge/ErrorReporter/DebugErrorReporter.php
@@ -23,10 +23,10 @@ class DebugErrorReporter implements ErrorReporter
     }
 
     /**
-     * @param \Exception      $exception
+     * @param \Throwable      $exception
      * @param \SS_HTTPRequest $request
      */
-    public function reportError(\Exception $exception, \SS_HTTPRequest $request = null)
+    public function reportError(\Throwable $exception, \SS_HTTPRequest $request = null)
     {
         if (!$this->envReporter->isLive()) {
             Debug::showError(

--- a/src/Camspiers/LoggerBridge/ErrorReporter/ErrorReporter.php
+++ b/src/Camspiers/LoggerBridge/ErrorReporter/ErrorReporter.php
@@ -7,5 +7,5 @@ namespace Camspiers\LoggerBridge\ErrorReporter;
  */
 interface ErrorReporter
 {
-    public function reportError(\Exception $exception, \SS_HTTPRequest $request = null);
+    public function reportError(\Throwable $exception, \SS_HTTPRequest $request = null);
 }

--- a/src/Camspiers/LoggerBridge/ErrorReporter/WhoopsPrettyErrorReporter.php
+++ b/src/Camspiers/LoggerBridge/ErrorReporter/WhoopsPrettyErrorReporter.php
@@ -33,10 +33,10 @@ class WhoopsPrettyErrorReporter implements ErrorReporter
     }
 
     /**
-     * @param \Exception      $exception
+     * @param \Throwable      $exception
      * @param \SS_HTTPRequest $request
      */
-    public function reportError(\Exception $exception, \SS_HTTPRequest $request = null)
+    public function reportError(\Throwable $exception, \SS_HTTPRequest $request = null)
     {
         if (!$this->envReporter->isLive()) {
             $whoops = new Run();

--- a/src/Camspiers/LoggerBridge/LoggerBridge.php
+++ b/src/Camspiers/LoggerBridge/LoggerBridge.php
@@ -471,10 +471,10 @@ class LoggerBridge implements \RequestFilter
 
     /**
      * Handles uncaught exceptions
-     * @param  \Exception  $exception
+     * @param  \Throwable  $exception
      * @return string|void
      */
-    public function exceptionHandler(\Exception $exception)
+    public function exceptionHandler(\Throwable $exception)
     {
         $context = array(
             'file'    => $exception->getFile(),


### PR DESCRIPTION
Hi there,

I noticed, pushing my new project on 3.6 on a server with php7.1, it was returning me errors like that:

![image](https://user-images.githubusercontent.com/12903433/26913631-4b56af9a-4c70-11e7-8f07-c539b0c8682e.png)

Changed the \Exception values for \Throwable values in different files to make it work again. 
What do you reckon? 

Cheers,
Clem. 