### PR TITLE
BUG Don't show HTML output for CLI / cron task errors

### DIFF
--- a/src/Camspiers/LoggerBridge/ErrorReporter/WhoopsPrettyErrorReporter.php
+++ b/src/Camspiers/LoggerBridge/ErrorReporter/WhoopsPrettyErrorReporter.php
@@ -4,6 +4,7 @@ namespace Camspiers\LoggerBridge\ErrorReporter;
 
 use Camspiers\LoggerBridge\EnvReporter\EnvReporter;
 use Debug;
+use Director;
 use Whoops\Handler\PrettyPageHandler;
 use Whoops\Run;
 
@@ -38,7 +39,7 @@ class WhoopsPrettyErrorReporter implements ErrorReporter
      */
     public function reportError($exception, \SS_HTTPRequest $request = null)
     {
-        if (!$this->envReporter->isLive()) {
+        if (Director::is_cli() || !$this->envReporter->isLive()) {
             $whoops = new Run();
             $whoops->pushHandler($this->prettyHandler)->handleException($exception);
         } else {


### PR DESCRIPTION
server error logs are filling up with useless HTML. This fixes that :)